### PR TITLE
Update install instructions

### DIFF
--- a/README.org
+++ b/README.org
@@ -214,7 +214,7 @@ This registers ~dendroam~ as a package to use in doom. Now inside of ~.doom.d/co
 
 #+begin_src emacs-lisp
 (use-package! dendroam
-  :after org)
+  :after org-roam)
 #+end_src
 
 * Future plans


### PR DESCRIPTION
I was getting 

```
error "org-roam-node-slug is already defined as something else than a generic function"
```

because dendroam was loading after `org-roam`. Dendroam overrides `org-roam-node-slug` so it needs to be defined before the override happens.

![roam](https://media0.giphy.com/media/12qL1aeSMOY9JS/giphy-downsized-medium.gif?cid=74e95743dxcapahqbmngeqquxkyw5k4pk2x8bxwhzv9j6f8r&rid=giphy-downsized-medium.gif&ct=g)